### PR TITLE
Add readable errors

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -8,4 +8,5 @@
              (compojure.api.sweet/DELETE)
              (compojure.api.sweet/OPTIONS)
              (compojure.api.sweet/POST)
-             (compojure.api.sweet/PUT)]}}}
+             (compojure.api.sweet/PUT)
+             (phrase.alpha/defphraser)]}}}

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,8 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  ;; Configuration file parsing
                  [aero "1.1.6"]
+                 ;; Human readable errors
+                 [phrase "0.3-alpha4"]
                  ;; Ring and compojure
                  [ring/ring-defaults "0.3.2"]
                  [metosin/compojure-api "2.0.0-alpha31"]

--- a/src/education/http/constants.clj
+++ b/src/education/http/constants.clj
@@ -1,4 +1,7 @@
-(ns education.http.constants)
+(ns education.http.constants
+  (:require [phrase.alpha :as p]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
 
 (def not-found-error-message "Resource not found")
 
@@ -21,3 +24,62 @@
 (def valid-decimal
   "Regex to check price."
   #"\d+(\.\d+)?")
+
+(def valid-username-regex
+  "Check new username using this regex."
+  #"^[a-zA-Z]+[a-zA-Z0-9]*$")
+
+(def valid-email-regex
+  "Check new email addresses using this regex."
+  #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+
+;; Phrases
+(p/defphraser #(contains? % key)
+  [_ _ key]
+  (format "Field %s is mandatory" (name key)))
+
+(p/defphraser #(re-matches valid-username-regex %)
+  [_ _]
+  "Username must start from letter")
+
+(p/defphraser #(>= (count %) min-length)
+  [_ {:keys [in]} min-length]
+  (str (str/capitalize (name (first in))) " must be at least " min-length " characters"))
+
+(p/defphraser (complement str/blank?)
+  [_ {:keys [in]}]
+  (str (str/capitalize (name (first in))) " must not be empty"))
+
+(p/defphraser #(<= (count %) max-length)
+  [_ {:keys [in]} max-length]
+  (str (str/capitalize (name (first in))) " must not be longer than " max-length " characters"))
+
+(p/defphraser (partial re-matches valid-url-regex)
+  [_ {:keys [in]}]
+  (str (str/capitalize (name (first in))) " URL is not valid"))
+
+(p/defphraser (partial re-matches valid-decimal)
+  [_ {:keys [in]}]
+  (str (str/capitalize (name (first in))) " is not valid"))
+
+(p/defphraser #(re-matches valid-email-regex %)
+  [_ _]
+  "Email is not valid")
+
+(p/defphraser :default
+  [_ {:keys [in]}]
+  (if (seq in)
+    (str (str/capitalize (name (first in))) " is not valid")
+    "Value is not valid"))
+
+;; Convert problems to
+(defn ->phrases
+  "Given a spec and a value x, phrases the first problem using context if any.
+
+  Returns nil if x is valid or no phraser was found. See phrase for details.
+  Use phrase directly if you want to phrase more than one problem."
+  [spec x]
+  (some->> (s/explain-data spec x)
+           ::s/problems
+           (mapv #(p/phrase {} %))
+           (filterv (complement nil?))))

--- a/src/education/http/constants.clj
+++ b/src/education/http/constants.clj
@@ -82,4 +82,5 @@
   (some->> (s/explain-data spec x)
            ::s/problems
            (mapv #(p/phrase {} %))
+           (distinct)
            (filterv (complement nil?))))

--- a/src/education/http/constants.clj
+++ b/src/education/http/constants.clj
@@ -33,6 +33,12 @@
   "Check new email addresses using this regex."
   #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
 
+(defn- ->prefix-or
+  [{:keys [in via]} or-value]
+  (->> (or (first in) (first via) or-value)
+       (name)
+       (str/capitalize)))
+
 ;; Phrases
 (p/defphraser #(contains? % key)
   [_ _ key]
@@ -43,34 +49,32 @@
   "Username must start from letter")
 
 (p/defphraser #(>= (count %) min-length)
-  [_ {:keys [in]} min-length]
-  (str (str/capitalize (name (first in))) " must be at least " min-length " characters"))
+  [_ problem min-length]
+  (str (->prefix-or problem "value") " must be at least " min-length " characters"))
 
 (p/defphraser (complement str/blank?)
-  [_ {:keys [in]}]
-  (str (str/capitalize (name (first in))) " must not be empty"))
+  [_ problem]
+  (str (->prefix-or problem "value") " must not be empty"))
 
 (p/defphraser #(<= (count %) max-length)
-  [_ {:keys [in]} max-length]
-  (str (str/capitalize (name (first in))) " must not be longer than " max-length " characters"))
+  [_ problem max-length]
+  (str (->prefix-or problem "value") " must not be longer than " max-length " characters"))
 
 (p/defphraser (partial re-matches valid-url-regex)
-  [_ {:keys [in]}]
-  (str (str/capitalize (name (first in))) " URL is not valid"))
+  [_ problem]
+  (str (->prefix-or problem "field") " URL is not valid"))
 
 (p/defphraser (partial re-matches valid-decimal)
-  [_ {:keys [in]}]
-  (str (str/capitalize (name (first in))) " is not valid"))
+  [_ problem]
+  (str (->prefix-or problem "value") " is not valid"))
 
 (p/defphraser #(re-matches valid-email-regex %)
   [_ _]
   "Email is not valid")
 
 (p/defphraser :default
-  [_ {:keys [in]}]
-  (if (seq in)
-    (str (str/capitalize (name (first in))) " is not valid")
-    "Value is not valid"))
+  [_ problem]
+  (str (->prefix-or problem "value") " is not valid"))
 
 ;; Convert problems to
 (defn ->phrases

--- a/src/education/http/routes.clj
+++ b/src/education/http/routes.clj
@@ -11,7 +11,8 @@
             [education.http.endpoints.upload :refer [upload-routes]]
             [education.http.endpoints.users :refer [users-routes]]
             [ring.util.http-response :as status]
-            [taoensso.timbre :refer [error trace]])
+            [taoensso.timbre :refer [error trace]]
+            [clojure.spec.alpha :as s])
   (:import java.sql.SQLException))
 
 (defn sql-exception-handler
@@ -29,11 +30,14 @@
 (defn request-validation-handler
   "Verify request body and raise error."
   []
-  (fn [^Exception e _ _]
-    (trace e "Invalid request")
-    (error "Invalid request" (.getMessage e))
-    (status/bad-request {:message const/bad-request-error-message
-                         :details (.getMessage e)})))
+  (fn [^Exception e ex-data request]
+    (let [spec (:spec ex-data)
+          body (:body-params request)
+          errors (const/->phrases spec body)]
+      (trace e "Invalid request")
+      (error "Invalid request" (s/explain spec body))
+      (status/bad-request {:message const/bad-request-error-message
+                           :errors  errors}))))
 
 (defn response-validation-handler
   "Return error in case of invalid response."

--- a/src/education/http/routes.clj
+++ b/src/education/http/routes.clj
@@ -35,19 +35,21 @@
           body (:body-params request)
           errors (const/->phrases spec body)]
       (trace e "Invalid request")
-      (error "Invalid request" (s/explain spec body))
+      (error "Invalid request" (s/explain-str spec body))
       (status/bad-request {:message const/bad-request-error-message
                            :errors  errors}))))
 
 (defn response-validation-handler
   "Return error in case of invalid response."
   []
-  (fn [^Exception e _ _]
-    (trace e "Invalid response")
-    (error "Invalid response" (.getMessage e))
-    (status/internal-server-error
-     {:message const/server-error-message
-      :details (.getMessage e)})))
+  (fn [^Exception e ex-data _]
+    (let [spec (:spec ex-data)
+          body (:response ex-data)]
+      (trace e "Invalid response")
+      (error "Invalid response" (s/explain spec body))
+      (status/internal-server-error
+       {:message const/server-error-message
+        :details (s/explain-str spec body)}))))
 
 (defn api-routes
   "Define top-level API routes."

--- a/src/education/specs/articles.clj
+++ b/src/education/specs/articles.clj
@@ -1,5 +1,6 @@
 (ns education.specs.articles
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
 
 (s/def ::id pos-int?)
 
@@ -7,11 +8,18 @@
 
 (s/def ::user-id-param pos-int?)
 
-(s/def ::title (s/and string? not-empty #(<= (count %) 100)))
+(s/def ::title
+  (s/and string?
+         (complement str/blank?)
+         #(<= (count %) 100)))
 
-(s/def ::body (s/and string? not-empty))
+(s/def ::body
+  (s/and string?
+         (complement str/blank?)))
 
-(s/def ::featured_image (s/and string? #(<= (count %) 500)))
+(s/def ::featured_image
+  (s/and string?
+         #(<= (count %) 500)))
 
 (s/def ::is_main_featured boolean?)
 

--- a/src/education/specs/common.clj
+++ b/src/education/specs/common.clj
@@ -1,19 +1,26 @@
 (ns education.specs.common
   (:require [clojure.spec.alpha :as s]
             [education.http.constants :as const]
-            [education.specs.gymnastics :as g]))
+            [education.specs.gymnastics :as g]
+            [clojure.string :as str]))
 
 (s/def ::id pos-int?)
 
 (s/def ::subtype_id pos-int?)
 
-(s/def ::title (s/and string? not-empty #(<= (count %) 500)))
+(s/def ::title
+  (s/and string?
+         (complement str/blank?)
+         #(<= (count %) 500)))
 
-(s/def ::subtitle (s/and string? not-empty #(<= (count %) 500)))
+(s/def ::subtitle
+  (s/and string?
+         (complement str/blank?)
+         #(<= (count %) 500)))
 
 (s/def ::url
   (s/and string?
-         not-empty
+         (complement str/blank?)
          (partial re-matches const/valid-url-regex)
          #(<= (count %) 1000)))
 
@@ -27,11 +34,13 @@
 (s/def ::screenshots
   (s/coll-of ::screenshot :kind vector? :distinct true :into []))
 
-(s/def ::description (s/and string? not-empty))
+(s/def ::description
+  (s/and string?
+         (complement str/blank?)))
 
 (s/def ::price
   (s/and string?
-         not-empty
+         (complement str/blank?)
          (partial re-matches const/valid-decimal)))
 
 (s/def ::size pos-int?)

--- a/src/education/specs/gymnastics.clj
+++ b/src/education/specs/gymnastics.clj
@@ -1,10 +1,11 @@
 (ns education.specs.gymnastics
   (:require [clojure.spec.alpha :as s]
-            [education.http.constants :as const]))
+            [education.http.constants :as const]
+            [clojure.string :as str]))
 
 (s/def ::picture
   (s/nilable
    (s/and string?
-          not-empty
+          (complement str/blank?)
           (partial re-matches const/valid-url-regex)
           #(<= (count %) 1000))))

--- a/src/education/specs/users.clj
+++ b/src/education/specs/users.clj
@@ -1,20 +1,17 @@
 (ns education.specs.users
-  (:require [clojure.spec.alpha :as s]))
-
-(def email-regex
-  "Check new email addresses using this regex."
-  #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+  (:require [clojure.spec.alpha :as s]
+            [education.http.constants :as const]))
 
 (s/def ::id int?)
 
 (s/def ::username
   (s/and string?
-         #(re-matches #"^[a-zA-Z]+[a-zA-Z0-9]*$" %)
+         #(re-matches const/valid-username-regex %)
          #(>= (count %) 2)))
 
 (s/def ::password (s/and string? #(>= (count %) 6)))
 
-(s/def ::email (s/and string? #(re-matches email-regex %)))
+(s/def ::email (s/and string? #(re-matches const/valid-email-regex %)))
 
 (s/def ::role #{"admin" "moderator" "guest"})
 

--- a/test/education/http/constants_test.clj
+++ b/test/education/http/constants_test.clj
@@ -1,0 +1,106 @@
+(ns education.http.constants-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [education.http.constants :as sut]
+            [education.specs.common :as spec]
+            [education.specs.users :as user-spec]
+            [clojure.string :as str]))
+
+(def test-data
+  "Test cases."
+  [[["Field url is mandatory"]
+    ::spec/presentation-create-request
+    {:title       "Title"
+     :description "Description"}]
+
+   [["Username must start from letter"]
+    ::user-spec/username
+    "1asdf"]
+
+   [["Username must start from letter"]
+    ::user-spec/user-create-request
+    {:username "1asdf"
+     :password "123456"
+     :email    "email@example.com"}]
+
+   [["Username must be at least 2 characters"]
+    ::user-spec/username
+    "a"]
+
+   [["Username must be at least 2 characters"]
+    ::user-spec/user-create-request
+    {:username "a"
+     :password "123456"
+     :email    "email@example.com"}]
+
+   [["Title must not be empty"]
+    ::spec/title
+    ""]
+
+   [["Title must not be empty"]
+    ::spec/presentation-create-request
+    {:title       ""
+     :url         "https://google.com/api/presentation"
+     :description "Description"}]
+
+   [["Title must not be longer than 500 characters"]
+    ::spec/title
+    (str/join (repeat 501 "a"))]
+
+   [["Title must not be longer than 500 characters"]
+    ::spec/presentation-create-request
+    {:title       (str/join (repeat 501 "a"))
+     :url         "https://google.com/api/presentation"
+     :description "Description"}]
+
+   [["Url URL is not valid"]
+    ::spec/url
+    "invalid"]
+
+   [["Url URL is not valid"]
+    ::spec/presentation-create-request
+    {:title       "Title"
+     :url         "invalid"
+     :description "Description"}]
+
+   [["Price is not valid"]
+    ::spec/price
+    "invalid"]
+
+   [["Price is not valid"]
+    ::spec/dress-create-request
+    {:title       "title"
+     :description "description"
+     :pictures    []
+     :size        22
+     :price       "invalid"}]
+
+   [["Email is not valid"]
+    ::user-spec/email
+    "invalid@email"]
+
+   [["Email is not valid"]
+    ::user-spec/user-create-request
+    {:username "username"
+     :password "123456"
+     :email    "invalid@email"}]
+
+   [["Id is not valid"]
+    ::spec/id
+    "invalid"]
+
+   [["Username is not valid"]
+    ::user-spec/user-create-request
+    {:username 123
+     :password "123456"
+     :email    "valid@email.com"}]
+
+   [["Field description is mandatory"
+     "Title must not be longer than 500 characters"]
+    ::spec/presentation-create-request
+    {:title (str/join (repeat 501 "a"))
+     :url   "https://google.com/api/presentation"}]])
+
+(deftest ->phrases-test
+  (doseq [[errors spec val] test-data]
+    (testing "Test conversion error to phrase"
+      (is (= errors (sut/->phrases spec val))))))

--- a/test/education/http/endpoints/upload_test.clj
+++ b/test/education/http/endpoints/upload_test.clj
@@ -54,4 +54,6 @@
                          (app))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
-        (is (= {:message const/bad-request-error-message} (dissoc body :details)))))))
+        (is (= {:message const/bad-request-error-message
+                :errors  ["Value is not valid"]}
+               body))))))

--- a/test/education/http/routes_test.clj
+++ b/test/education/http/routes_test.clj
@@ -4,7 +4,9 @@
             [education.http.endpoints.presentations :as presentations-endpoint]
             [education.http.endpoints.test-app :as test-app]
             [ring.mock.request :as mock]
-            [spy.core :as spy])
+            [spy.core :as spy]
+            [clojure.spec.alpha :as s]
+            [education.specs.common :as spec])
   (:import java.time.Instant))
 
 (def ^:private presentation-response-invalid
@@ -13,8 +15,8 @@
    :title       "Title"
    :url         "invalid url"
    :description "Some description"
-   :created_on  (str (Instant/now))
-   :updated_on  (str (Instant/now))})
+   :created_on  (Instant/now)
+   :updated_on  (Instant/now)})
 
 (deftest response-validation-handler-test
   (testing "Test exception handler for invalid response body"
@@ -23,5 +25,6 @@
             response (app (mock/request :get "/api/presentations/22"))
             body     (test-app/parse-body (:body response))]
         (is (= 500 (:status response)))
-        (is (= {:message const/server-error-message} (dissoc body :details)))
-        (is (contains? body :details))))))
+        (is (= {:message const/server-error-message
+                :details (s/explain-str ::spec/presentation-response presentation-response-invalid)}
+               body))))))

--- a/test/education/test_data.clj
+++ b/test/education/test_data.clj
@@ -46,8 +46,8 @@
    :users/user_name     (:username add-user1-request)
    :users/user_password (hs/encrypt password)
    :users/user_email    (:email add-user1-request)
-   :users/created_on    (Instant/now)
-   :users/updated_on    (Instant/now)})
+   :users/created_on    (Instant/parse "2020-12-12T18:22:12Z")
+   :users/updated_on    (Instant/parse "2020-12-12T19:22:12Z")})
 
 (def db-test-user2
   "Second mocked testing user."
@@ -55,8 +55,8 @@
    :users/user_name     (:username add-user2-request)
    :users/user_password (hs/encrypt password)
    :users/user_email    (:email add-user2-request)
-   :users/created_on    (Instant/now)
-   :users/updated_on    (Instant/now)})
+   :users/created_on    (Instant/parse "2019-12-12T18:22:12Z")
+   :users/updated_on    (Instant/parse "2019-12-12T18:22:12Z")})
 
 (def db-all-roles
   "All roles from database."
@@ -129,8 +129,8 @@
    :articles/body             (:body add-article-request)
    :articles/description      "Test description"
    :articles/is_main_featured false
-   :articles/created_on       (Instant/now)
-   :articles/updated_on       (Instant/now)})
+   :articles/created_on       (Instant/parse "2020-12-12T13:22:12Z")
+   :articles/updated_on       (Instant/parse "2020-12-12T15:22:12Z")})
 
 (def application-json
   "Content-Type header value for mock requests."


### PR DESCRIPTION
Currently errors are constants and very unclear. I'm going to use `phrase`
library to return human readable error messages.