### PR TITLE
[#40] Add attachment and is_public fields for presentations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,5 +43,6 @@
                                   [peridot "0.5.3"]
                                   [org.clojure/test.check "1.0.0"]]}
              :uberjar {:aot :all}}
-  :plugins [[lein-cloverage "1.1.2"]]
+  :plugins [[lein-cloverage "1.1.2"]
+            [lein-cljfmt "0.7.0"]]
   :main education.core)

--- a/resources/migrations/009-add-presentation-attachment-and-is-public.down.sql
+++ b/resources/migrations/009-add-presentation-attachment-and-is-public.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE presentations DROP COLUMN attachment;
+--;;
+ALTER TABLE presentations DROP COLUMN description;

--- a/resources/migrations/009-add-presentation-attachment-and-is-public.up.sql
+++ b/resources/migrations/009-add-presentation-attachment-and-is-public.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE presentations ADD COLUMN attachment VARCHAR(1000);
+--;;
+ALTER TABLE presentations ADD COLUMN is_public BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/education/database/presentations.clj
+++ b/src/education/database/presentations.clj
@@ -4,10 +4,10 @@
 
 (defn add-presentation
   "Create new `presentation` entry in database with given `conn`."
-  [conn presentation]
-  (-> conn
-      (sql/insert! :presentations presentation)
-      (:presentations/id)))
+  [conn {:keys [is_public] :as presentation :or {is_public true}}]
+  (->> (assoc presentation :is_public is_public)
+       (sql/insert! conn :presentations)
+       (:presentations/id)))
 
 (defn update-presentation
   "Update existing `presentation` entry by `presentation-id` with given `conn`."
@@ -30,7 +30,11 @@
                    :limit (or limit 20)
                    :offset (or offset 0))
        (hsql/format)
-       (sql/query conn)))
+       (sql/query conn)
+       (map (fn [presentation]
+              (if (:is_public presentation)
+                (dissoc presentation :url)
+                presentation)))))
 
 (defn delete-presentation
   "Delete presentation by `presentation-id` with given `conn`."

--- a/src/education/http/restructure.clj
+++ b/src/education/http/restructure.clj
@@ -6,12 +6,12 @@
             [ring.util.http-response :refer [forbidden unauthorized]]))
 
 #_(defn- expire?
-  "Check if `user` data from token is expired."
-  [user]
-  (let [now (quot (System/currentTimeMillis) 1000)]
-    (if (> now (:exp user))
-      user
-      nil)))
+    "Check if `user` data from token is expired."
+    [user]
+    (let [now (quot (System/currentTimeMillis) 1000)]
+      (if (> now (:exp user))
+        user
+        nil)))
 
 (defn has-role?
   "Check if `user` has one or many of `required-roles`."

--- a/src/education/specs/common.clj
+++ b/src/education/specs/common.clj
@@ -27,6 +27,7 @@
 ;; Aliases for ::url
 (s/def ::picture ::url)
 (s/def ::screenshot ::url)
+(s/def ::attachment ::url)
 
 (s/def ::pictures
   (s/coll-of ::picture :kind vector? :distinct true :into []))
@@ -44,6 +45,8 @@
          (partial re-matches const/valid-decimal)))
 
 (s/def ::size pos-int?)
+
+(s/def ::is_public boolean?)
 
 (s/def ::created_on inst?)
 
@@ -113,13 +116,15 @@
 
 ;; Presentations
 (s/def ::presentation-create-request
-  (s/keys :req-un [::title ::url ::description]))
+  (s/keys :req-un [::title ::url ::description]
+          :opt-un [::attachment ::is_public]))
 
 (s/def ::presentation-update-request
-  (s/keys :opt-un [::title ::url ::description]))
+  (s/keys :opt-un [::title ::url ::description ::attachment ::is_public]))
 
 (s/def ::presentation-response
-  (s/keys :req-un [::id ::title ::url ::description ::created_on ::updated_on]))
+  (s/keys :req-un [::id ::title ::description ::is_public ::created_on ::updated_on]
+          :opt-un [::url ::attachment]))
 
 (s/def ::presentations-response
   (s/coll-of ::presentation-response :kind vector? :distinct true :into []))

--- a/src/education/utils/maps.clj
+++ b/src/education/utils/maps.clj
@@ -30,3 +30,7 @@
   "Take map `m` with kebab or snake case keys and produce new one with snake case."
   [m]
   (apply hash-map (mapcat ->camel-key m)))
+
+(defn remove-nils
+  [m]
+  (apply dissoc m (for [[k v] m :when (nil? v)] k)))

--- a/test/education/database/articles_test.clj
+++ b/test/education/database/articles_test.clj
@@ -52,10 +52,10 @@
                   :body           (:body td/add-article-request)
                   :featured_image (:featured_image td/add-article-request)
                   :updated_on     now}
-                (assoc query :updated_on now)))
-         (is (= :articles table))
-         (is (= {:id (:articles/id td/db-test-article)} opts))
-         (is (= updated-rows result))))))
+                 (assoc query :updated_on now)))
+          (is (= :articles table))
+          (is (= {:id (:articles/id td/db-test-article)} opts))
+          (is (= updated-rows result))))))
 
   (testing "Test update article with empty body"
     (let [updated-rows 2]
@@ -63,10 +63,10 @@
         (let [article-id             42
               result                 (sut/update-article nil article-id {})
               [[_ table query opts]] (spy/calls sql/update!)]
-         (is (= (list :updated_on) (keys query)))
-         (is (= :articles table))
-         (is (= {:id article-id} opts))
-         (is (= updated-rows result)))))))
+          (is (= (list :updated_on) (keys query)))
+          (is (= :articles table))
+          (is (= {:id article-id} opts))
+          (is (= updated-rows result)))))))
 
 (def get-all-articles-query
   "Expected raw SQL query for fetching all articles from database."

--- a/test/education/http/endpoints/articles_test.clj
+++ b/test/education/http/endpoints/articles_test.clj
@@ -287,7 +287,6 @@
                 :errors  ["Value is not valid"]}
                body))))))
 
-
 (deftest get-latest-articles-test
   (testing "Test GET /articles/latest with valid limit parameter"
     (with-redefs [articlesdb/get-latest-full-sized-articles

--- a/test/education/http/endpoints/upload_test.clj
+++ b/test/education/http/endpoints/upload_test.clj
@@ -44,7 +44,7 @@
             [[_ name]] (spy/calls sut/write-file)]
         (is (= 200 (:status response)))
         (is (= {:url (str (config/base-url td/test-config) "/img/" test-uuid "_" test-img-name)} body))
-        (is (= (str (config/storage-path td/test-config) "img/" test-uuid "_" test-img-name) name )))))
+        (is (= (str (config/storage-path td/test-config) "img/" test-uuid "_" test-img-name) name)))))
 
   (testing "Test POST /upload with invalid request"
     (with-redefs [sut/write-file (spy/spy)]

--- a/test/education/http/routes_test.clj
+++ b/test/education/http/routes_test.clj
@@ -1,30 +1,32 @@
 (ns education.http.routes-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer [deftest is testing]]
             [education.http.constants :as const]
-            [education.http.endpoints.presentations :as presentations-endpoint]
+            [education.http.endpoints.dresses :as dresses-endpoint]
             [education.http.endpoints.test-app :as test-app]
+            [education.specs.common :as spec]
             [ring.mock.request :as mock]
-            [spy.core :as spy]
-            [clojure.spec.alpha :as s]
-            [education.specs.common :as spec])
+            [spy.core :as spy])
   (:import java.time.Instant))
 
-(def ^:private presentation-response-invalid
-  "Invalid API presentation response."
+(def ^:private dress-response-invalid
+  "Invalid API dress response."
   {:id          22
    :title       "Title"
-   :url         "invalid url"
-   :description "Some description"
+   :description "Description"
+   :size        38
+   :pictures    ["invalid url"]
+   :price       "22.7"
    :created_on  (Instant/now)
    :updated_on  (Instant/now)})
 
 (deftest response-validation-handler-test
   (testing "Test exception handler for invalid response body"
-    (with-redefs [presentations-endpoint/get-presentation-by-id-handler (spy/stub presentation-response-invalid)]
+    (with-redefs [dresses-endpoint/get-dress-by-id-handler (spy/stub dress-response-invalid)]
       (let [app      (test-app/api-routes-with-auth)
-            response (app (mock/request :get "/api/presentations/22"))
+            response (app (mock/request :get "/api/dresses/22"))
             body     (test-app/parse-body (:body response))]
         (is (= 500 (:status response)))
         (is (= {:message const/server-error-message
-                :details (s/explain-str ::spec/presentation-response presentation-response-invalid)}
+                :details (s/explain-str ::spec/dress-response dress-response-invalid)}
                body))))))

--- a/test/education/specs/articles_test.clj
+++ b/test/education/specs/articles_test.clj
@@ -89,7 +89,7 @@
     (testing (str "::description is valid " description)
       (is (s/valid? ::sut/description description))))
 
-  (doseq [description [ false 1234 []]]
+  (doseq [description [false 1234 []]]
     (testing (str "::description is invalid " description)
       (is (not (s/valid? ::sut/description description))))))
 

--- a/test/education/specs/common_test.clj
+++ b/test/education/specs/common_test.clj
@@ -118,6 +118,30 @@
     (testing (str "::screenshots is invalid " screenshots)
       (is (not (s/valid? ::sut/screenshots screenshots))))))
 
+(deftest attachment-test
+  (doseq [attachment ["http://insecure.com"
+                      "https://secure.net/some.img.jpg"
+                      "https://some.url/"
+                      "http://127.0.0.1:3000/some_image.jpg"
+                      (str "https://some.url/" (str/join (repeat 979 "a")) ".jpg")]]
+    (testing (str "::attachment is valid " attachment)
+      (is (s/valid? ::sut/attachment attachment))))
+
+  (doseq [attachment ["juststring"
+                      "www.attachment.com/image.jpg"
+                      (str "https://some.url/" (str/join (repeat 980 "a")) ".jpg")]]
+    (testing (str "::attachment is invalid " attachment)
+      (is (not (s/valid? ::sut/attachment attachment))))))
+
+(deftest is-public-test
+  (doseq [is-public [true false]]
+    (testing (str "::is-public is valid " is-public)
+      (is (s/valid? ::sut/is_public is-public))))
+
+  (doseq [is-public ["string" 123 nil [] #{} :keyword]]
+    (testing (str "::is-public is invalid")
+      (is ((complement s/valid?) ::sut/is_public is-public)))))
+
 (deftest created-on-test
   (testing "::created_on is valid"
     (is (s/valid? ::sut/created_on (Instant/now))))
@@ -227,7 +251,7 @@
     (is (s/valid? ::sut/gymnastics-response [gymnastic-response gymnastic-response2])))
 
   (testing "::gymnastics-response is invalid"
-    (is (not (s/valid? ::sut/gymnastics-response [gymnastic-response gymnastic-response ])))))
+    (is (not (s/valid? ::sut/gymnastics-response [gymnastic-response gymnastic-response])))))
 
 (def ^:private dress-create-request
   {:title       "Dress title"
@@ -432,17 +456,22 @@
 (def ^:private presentation-create-request
   {:title       "My awesome presentation"
    :url         "https://google.com/api/presentations/bla-bla-bla"
-   :description "This presentations is about bla-bla-bla"})
+   :description "This presentations is about bla-bla-bla"
+   :is_public   false
+   :attachment  "https://alenkinaskazka.net/some_file.pdf"})
 
 (deftest presentation-create-request-test
-  (testing "::presentations-create-request is valid"
-    (is (s/valid? ::sut/presentation-create-request presentation-create-request)))
+  (doseq [request [presentation-create-request
+                   (dissoc presentation-create-request :is_public)
+                   (dissoc presentation-create-request :attachment)]]
+    (testing "::presentations-create-request is valid"
+      (is (s/valid? ::sut/presentation-create-request request))))
 
   (doseq [request [(dissoc presentation-create-request :title)
                    (dissoc presentation-create-request :url)
                    (dissoc presentation-create-request :description)]]
     (testing "::presentation-create-request is invalid"
-      (is (not (s/valid? ::sut/presentation-create-request request))))))
+      (is ((complement s/valid?) ::sut/presentation-create-request request)))))
 
 (deftest presentations-update-request-test
   (doseq [request [{}
@@ -457,28 +486,32 @@
    :title       "First title"
    :url         "https://google.com/first/presentation"
    :description "First presentation description"
+   :is_public   false
    :created_on  (Instant/now)
    :updated_on  (Instant/now)})
 
 (def ^:private presentation-response2
   {:id          2
    :title       "Second title"
-   :url         "https://google.com/second/presentation"
    :description "Second presentation description"
+   :is_public   false
+   :attachment  "https://alenkinaskazka.net/some-file.pdf"
    :created_on  (Instant/now)
    :updated_on  (Instant/now)})
 
 (deftest presentation-response-test
-  (testing "::presentation-response is valid"
-    (is (s/valid? ::sut/presentation-response presentation-response)))
+  (doseq [response [presentation-response
+                    presentation-response2]]
+    (testing "::presentation-response is valid"
+      (is (s/valid? ::sut/presentation-response response))))
 
   (doseq [response [(dissoc presentation-response :id)
                     (dissoc presentation-response :title)
-                    (dissoc presentation-response :url)
                     (dissoc presentation-response :description)
+                    (dissoc presentation-response :is_public)
                     (dissoc presentation-response :created_on)
                     (dissoc presentation-response :updated_on)]]
-    (is (not (s/valid? ::sut/presentation-response response)))))
+    (is ((complement s/valid?) ::sut/presentation-response response))))
 
 (deftest presentations-response-test
   (testing "::presentations-response is valid"
@@ -488,4 +521,4 @@
   (doseq [response [[presentation-response presentation-response]
                     #{presentation-response presentation-response2}]]
     (testing "::presentations-response is invalid"
-      (is (not (s/valid? ::sut/presentations-response response))))))
+      (is ((complement s/valid?) ::sut/presentations-response response)))))

--- a/test/education/test_data.clj
+++ b/test/education/test_data.clj
@@ -119,7 +119,7 @@
   "Article to create."
   {:title          "Test title",
    :body           "Test body",
-   :featured_image "https://featured.image.com/image.png",})
+   :featured_image "https://featured.image.com/image.png"})
 
 (def db-test-article
   "Created article."

--- a/test/education/utils/maps_test.clj
+++ b/test/education/utils/maps_test.clj
@@ -64,3 +64,8 @@
                               :some_title "Some title"
                               :sub-title  "Subtitle"
                               :newField   33})))))
+
+(deftest remove-nils-test
+  (testing "Test remove-nils"
+    (is (= {:id 1 :some_title "Title"}
+           (sut/remove-nils {:id 1 :some_title "Title" :attachment nil})))))


### PR DESCRIPTION
- Presentations with is_public=false now returned without url
- Get presentation by ID now requires authorization token
- New fields are optional in request bodies, if is_public is omitted it will be
  set to true by default