### PR TITLE
Filter non public presentations url

### DIFF
--- a/src/education/database/presentations.clj
+++ b/src/education/database/presentations.clj
@@ -32,9 +32,9 @@
        (hsql/format)
        (sql/query conn)
        (map (fn [presentation]
-              (if (:is_public presentation)
-                (dissoc presentation :url)
-                presentation)))))
+              (if (:presentations/is_public presentation)
+                presentation
+                (dissoc presentation :presentations/url))))))
 
 (defn delete-presentation
   "Delete presentation by `presentation-id` with given `conn`."

--- a/test/education/database/presentations_test.clj
+++ b/test/education/database/presentations_test.clj
@@ -122,7 +122,7 @@
   (testing "Test get all presentation filter URLs from non-public"
     (with-redefs [sql/query (spy/stub [create-presentation-result create-presentation-result-not-public])]
       (let [result (sut/get-all-presentations nil)]
-        (is (= [create-presentation-result (dissoc create-presentation-result-not-public :url)] result))
+        (is (= [create-presentation-result (dissoc create-presentation-result-not-public :presentations/url)] result))
         (is (spy/called-once-with? sql/query nil [get-all-presentations-query 20 0]))))))
 
 (def ^:private delete-presentation-result


### PR DESCRIPTION
Current implementation is incorrect due to usage non-qualified keywords.