### PR TITLE
Mandatory subtype_id for presentations

### DIFF
--- a/src/education/database/presentations.clj
+++ b/src/education/database/presentations.clj
@@ -23,9 +23,10 @@
 
 (defn get-all-presentations
   "Get all presentations from database with given `conn`."
-  [conn & {:keys [limit offset]}]
+  [conn subtype-id & {:keys [limit offset]}]
   (->> (hsql/build :select :*
                    :from :presentations
+                   :where [:= :subtype_id subtype-id]
                    :order-by [[:updated_on :desc]]
                    :limit (or limit 20)
                    :offset (or offset 0))

--- a/src/education/http/endpoints/presentations.clj
+++ b/src/education/http/endpoints/presentations.clj
@@ -27,8 +27,8 @@
     (status/not-found {:message const/not-found-error-message})))
 
 (defn- get-all-presentations-handler
-  [db limit offset]
-  (->> (presentations-db/get-all-presentations db :limit limit :offset offset)
+  [db subtype-id limit offset]
+  (->> (presentations-db/get-all-presentations db subtype-id :limit limit :offset offset)
        (mapv unqualify-map)
        (mapv remove-nils)
        (status/ok)))
@@ -87,7 +87,8 @@
                        :schema      ::spec/error-response}}
       (get-presentation-by-id-handler db presentation-id))
     (GET "/" []
-      :query-params [{limit :- ::spec/limit nil}
+      :query-params [subtype_id :- ::spec/subtype_id
+                     {limit :- ::spec/limit nil}
                      {offset :- ::spec/offset nil}]
       :summary "Get all presentations"
       :description "Get list of presentations with given optionsl `limit` and `offset`"
@@ -95,7 +96,7 @@
                        :schema      ::spec/presentations-response}
                   400 {:description const/bad-request-error-message
                        :schema      ::spec/error-response}}
-      (get-all-presentations-handler db limit offset))
+      (get-all-presentations-handler db subtype_id limit offset))
     (DELETE "/:presentation-id" []
       :middleware [[require-roles #{:admin}]]
       :path-params [presentation-id :- ::spec/id]

--- a/test/education/database/presentations_test.clj
+++ b/test/education/database/presentations_test.clj
@@ -110,34 +110,46 @@
 
 (def ^:private get-all-presentations-query
   "Expected SQL query to get all presentations."
-  "SELECT * FROM presentations ORDER BY updated_on DESC LIMIT ? OFFSET ?")
+  "SELECT * FROM presentations WHERE subtype_id = ? ORDER BY updated_on DESC LIMIT ? OFFSET ?")
+
+(def ^:private get-all-presentations-subtype-id
+  "Test API subtype-id."
+  3)
 
 (deftest get-all-presentations-test
   (testing "Test get all presentations without optional parameters"
     (with-redefs [sql/query (spy/stub [create-presentation-result])]
-      (let [result (sut/get-all-presentations nil)]
+      (let [result (sut/get-all-presentations nil get-all-presentations-subtype-id)]
         (is (= [create-presentation-result] result))
-        (is (spy/called-once-with? sql/query nil [get-all-presentations-query 20 0])))))
+        (is (spy/called-once-with? sql/query
+                                   nil
+                                   [get-all-presentations-query get-all-presentations-subtype-id 20 0])))))
 
   (testing "Test get all presentations with limit specified"
     (with-redefs [sql/query (spy/stub [create-presentation-result])]
       (let [limit  1
-            result (sut/get-all-presentations nil :limit limit)]
+            result (sut/get-all-presentations nil get-all-presentations-subtype-id :limit limit)]
         (is (= [create-presentation-result] result))
-        (is (spy/called-once-with? sql/query nil [get-all-presentations-query limit 0])))))
+        (is (spy/called-once-with? sql/query
+                                   nil
+                                   [get-all-presentations-query get-all-presentations-subtype-id limit 0])))))
 
   (testing "Test get all presentations with offset specified"
     (with-redefs [sql/query (spy/stub [create-presentation-result])]
       (let [offset 20
-            result (sut/get-all-presentations nil :offset offset)]
+            result (sut/get-all-presentations nil get-all-presentations-subtype-id :offset offset)]
         (is (= [create-presentation-result] result))
-        (is (spy/called-once-with? sql/query nil [get-all-presentations-query 20 offset])))))
+        (is (spy/called-once-with? sql/query
+                                   nil
+                                   [get-all-presentations-query get-all-presentations-subtype-id 20 offset])))))
 
   (testing "Test get all presentation filter URLs from non-public"
     (with-redefs [sql/query (spy/stub [create-presentation-result create-presentation-result-not-public])]
-      (let [result (sut/get-all-presentations nil)]
+      (let [result (sut/get-all-presentations nil get-all-presentations-subtype-id)]
         (is (= [create-presentation-result (dissoc create-presentation-result-not-public :presentations/url)] result))
-        (is (spy/called-once-with? sql/query nil [get-all-presentations-query 20 0]))))))
+        (is (spy/called-once-with? sql/query
+                                   nil
+                                   [get-all-presentations-query get-all-presentations-subtype-id 20 0]))))))
 
 (def ^:private delete-presentation-result
   "Stub data for delete presentation call."


### PR DESCRIPTION
New required query param `subtype_id` for presentations