### PR TITLE
Add free-lesson endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://educationapp-api.herokuapp.com/swagger"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
                  ;; Configuration file parsing
                  [aero "1.1.6"]
                  ;; Human readable errors
@@ -28,6 +28,10 @@
                  [buddy/buddy-hashers "1.4.0"]
                  [buddy/buddy-sign "3.1.0"]
                  [buddy/buddy-auth "2.2.0"]
+                 ;; Send mail
+                 [com.draines/postal "2.0.4"]
+                 ;; Template rendering
+                 [de.ubercode.clostache/clostache "1.4.0"]
                  ;; Logging
                  [com.taoensso/timbre "5.1.1"]
                  ;; JSON parsing

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject education-api "1.4.0"
+(defproject education-api "1.4.0-SNAPSHOT"
   :description "Back end for education web application"
   :url "http://educationapp-api.herokuapp.com/swagger"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
+            :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.3"]
                  ;; Configuration file parsing
                  [aero "1.1.6"]
@@ -28,27 +28,33 @@
                  [buddy/buddy-hashers "1.4.0"]
                  [buddy/buddy-sign "3.1.0"]
                  [buddy/buddy-auth "2.2.0"]
-                 ;; Send mail
-                 [com.draines/postal "2.0.4"]
-                 ;; Template rendering
-                 [de.ubercode.clostache/clostache "1.4.0"]
                  ;; Logging
                  [com.taoensso/timbre "5.1.1"]
                  ;; HTTP client
                  [clj-http "3.10.3"]
-                 ;; JSON parsing
-                 [com.fasterxml.jackson.core/jackson-core "2.11.1"]]
+                 ;; Content-type negotiation
+                 [metosin/muuntaja "0.6.8"]]
   :repl-options {:init-ns education.core}
+  :release-tasks [["vcs" "assert-committed"]
+                  ["change" "version"
+                   "leiningen.release/bump-version" "release"]
+                  ["vcs" "commit"]
+                  ["vcs" "tag"]
+                  ["change" "version" "leiningen.release/bump-version"]
+                  ["vcs" "commit"]
+                  ["vcs" "push"]]
   :aliases {"migrate"  ["run" "-m" "education.database.migrations/migrate" "--"]
             "rollback" ["run" "-m" "education.database.migrations/rollback" "--"]}
   :uberjar-name "education-api-standalone.jar"
   :min-lein-version "2.0.0"
-  :profiles {:dev {:resource-paths ["test-resources"]
-                   :dependencies [[tortue/spy "2.0.0"]
-                                  [ring/ring-mock "0.4.0"]
-                                  [peridot "0.5.3"]
-                                  [org.clojure/test.check "1.0.0"]]}
-             :uberjar {:aot :all}}
+  :profiles {:dev
+             {:resource-paths ["test-resources"]
+              :dependencies   [[tortue/spy "2.4.0"]
+                               [ring/ring-mock "0.4.0"]
+                               ;; Create multipart entity (consider removing this)
+                               [peridot "0.5.3"]]}
+             :uberjar
+             {:aot :all}}
   :plugins [[lein-cloverage "1.1.2"]
             [lein-cljfmt "0.7.0"]]
   :main education.core)

--- a/project.clj
+++ b/project.clj
@@ -18,10 +18,10 @@
                  ;; [metosin/ring-swagger-ui "3.25.0"]
                  ;; Database stuff
                  [ragtime "0.8.0"]
-                 [seancorfield/next.jdbc "1.1.588"]
+                 [com.github.seancorfield/next.jdbc "1.1.643"]
                  [org.postgresql/postgresql "42.2.14"]
                  [com.mchange/c3p0 "0.9.5.5"]
-                 [honeysql "0.9.10"]
+                 [com.github.seancorfield/honeysql "2.0.0-alpha3"]
                  ;; Integrant framework
                  [integrant "0.8.0"]
                  ;; Security
@@ -34,6 +34,8 @@
                  [de.ubercode.clostache/clostache "1.4.0"]
                  ;; Logging
                  [com.taoensso/timbre "5.1.1"]
+                 ;; HTTP client
+                 [clj-http "3.10.3"]
                  ;; JSON parsing
                  [com.fasterxml.jackson.core/jackson-core "2.11.1"]]
   :repl-options {:init-ns education.core}

--- a/resources/config/config.edn
+++ b/resources/config/config.edn
@@ -4,14 +4,36 @@
  {:url #profile
   {:dev  #ref [:secrets :dburi]
    :prod #env JDBC_DATABASE_URL}}
+
  :app
  {:port      #long #or [#env PORT 3000]
-  :base_url #profile
-  {:dev "http://127.0.0.1:3000"
+  :base_url  #profile
+  {:dev  "http://127.0.0.1:3000"
    :prod #env BASE_URL}
-  :storage #profile
-  {:dev "/home/rrudakov/tmp/"
+  :storage   #profile
+  {:dev  "/home/rrudakov/tmp/"
    :prod #env STORAGE_PATH}
   :tokensign #profile
   {:dev  #ref [:secrets :tokensign]
-   :prod #env SECRET}}}
+   :prod #env SECRET}
+  :crypto
+  {:key #profile
+   {:dev  #ref [:secrets :crypto-key]
+    :prod #env CRYPTO_KEY}
+   :iv  #profile
+   {:dev  #ref [:secrets :crypto-iv]
+    :prod #env CRYPTO_IV}}
+  :send-grid
+  {:base-url "https://api.sendgrid.com/v3"
+   :api-key  #profile
+   {:dev  #ref [:secrets :send-grid-api-key]
+    :prod #env SEND_GRID_API_KEY}
+   :templates
+   {:free-lesson "d-3d1491f539ae45328b15983e7619fd4e"}}
+  :video-lessons
+  {:root-path        #profile
+   {:dev  #ref [:secrets :video-lessons-root-path]
+    :prod #env VIDEO_LESSONS_ROOT_PATH}
+   :free-lesson-path #profile
+   {:dev  "zima.mp4"
+    :prod #env FREE_VIDEO_LESSON_PATH}}}}

--- a/resources/config/config_test.edn
+++ b/resources/config/config_test.edn
@@ -6,4 +6,21 @@
  {:port      #long #or [#env PORT 3000]
   :tokensign #profile
   {:dev  "not_super_secure_token"
-   :prod "super_secure_token"}}}
+   :prod "super_secure_token"}
+  :base_url  #profile
+  {:dev  "http://127.0.0.1:3000"
+   :prod "https://prod.url"}
+  :storage   #profile
+  {:dev  "/tmp/"
+   :prod "/prod/storage"}
+  :crypto
+  {:key "key"
+   :iv  "iv"}
+  :send-grid
+  {:base-url "https://api.url"
+   :api-key  "api-key"
+   :templates
+   {:free-lesson "free-lesson-template-id"}}
+  :video-lessons
+  {:root-path        "/some/storage"
+   :free-lesson-path "zima.mp4"}}}

--- a/resources/migrations/012-create-email-subscriptions-table.down.sql
+++ b/resources/migrations/012-create-email-subscriptions-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE email_subscriptions;

--- a/resources/migrations/012-create-email-subscriptions-table.up.sql
+++ b/resources/migrations/012-create-email-subscriptions-table.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE email_subscriptions (
+  email VARCHAR(500) PRIMARY KEY,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE
+);

--- a/resources/templates/free-lesson.mustache
+++ b/resources/templates/free-lesson.mustache
@@ -1,0 +1,173 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Free lesson</title>
+    <style>
+    /* -------------------------------------
+        INLINED WITH htmlemail.io/inline
+    ------------------------------------- */
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+            table[class=body] ul,
+            table[class=body] ol,
+            table[class=body] td,
+            table[class=body] span,
+            table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+            table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+    }
+
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+            .ExternalClass p,
+            .ExternalClass span,
+            .ExternalClass font,
+            .ExternalClass td,
+            .ExternalClass div {
+        line-height: 100%;
+      }
+      .apple-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+      .btn-primary table td:hover {
+        background-color: #34495e !important;
+      }
+      .btn-primary a:hover {
+        background-color: #34495e !important;
+        border-color: #34495e !important;
+      }
+    }
+    </style>
+  </head>
+  <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 16px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Бесплатный видео-урок.</span>
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
+      <tr>
+        <td style="font-family: sans-serif; font-size: 16px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: sans-serif; font-size: 16px; vertical-align: top; display: block; Margin: 0 auto; max-width: 780px; padding: 10px; width: 780px;">
+          <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 780px; padding: 10px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 3px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: sans-serif; font-size: 16px; vertical-align: top; box-sizing: border-box; padding: 20px;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                    <tr>
+                      <td style="font-family: sans-serif; font-size: 16px; vertical-align: top;">
+                        <img src="https://alenkinaskazka.net/static/media/logo.00b5297e.png" alt="Logo" height="100" border="0" style="border:0; outline:none; text-decoration:none; display:block;">
+                        <h3 style="font-family: sans-serif;">Бесплатный урок видео-урок</h3>
+                        <p style="font-family: sans-serif; font-size: 16px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                          Вы получили это письмо, так как оставили заявку на сайте <a href="https://alenkinaskazka.net" target="_blank" rel="noopener">alenkinaskazka</a>.
+                        </p>
+                        <p style="font-family: sans-serif; font-size: 16px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                          Чтобы получить доступ к видео-уроку нажмите кнопку.
+                        </p>
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="center" style="font-family: sans-serif; font-size: 16px; vertical-align: top; padding-bottom: 15px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="font-family: sans-serif; font-size: 16px; vertical-align: top; background-color: #3498db; border-radius: 5px; text-align: center;">
+                                        <a href="https://alenkinaskazka.net/free-lesson?token={{ token }}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #3498db; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: #3498db;">
+                                          Бесплатный видео-урок
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                          Образовательный портал для детей и родителей "Алёнкина сказка".
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- START FOOTER -->
+            <div class="footer" style="clear: both; Margin-top: 10px; text-align: center; width: 100%;">
+              <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                <tr>
+                  <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;">
+                    <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center;">Алёнкина сказка</span>
+                    <br>Вы не оставляли заявку на сайте или получили это письмо по ошибке? Вы можете <a href="http://i.imgur.com/CScmqnj.gif" style="text-decoration: underline; color: #999999; font-size: 12px; text-align: center;">отписаться</a> от рассылки.
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <!-- END FOOTER -->
+
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/src/education/config.clj
+++ b/src/education/config.clj
@@ -1,7 +1,9 @@
 (ns education.config
   (:require [aero.core :refer [read-config]]
             [buddy.auth.backends.token :refer [jws-backend]]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [buddy.core.hash :as hash]
+            [buddy.core.codecs :as codecs]))
 
 (defn config
   "Read application config from resources."
@@ -48,3 +50,31 @@
   "Return path to the file storage."
   [config]
   (get-in config [:app :storage]))
+
+(defn crypto-key
+  [config]
+  (hash/sha256 (get-in config [:app :crypto :key])))
+
+(defn crypto-iv
+  [config]
+  (codecs/str->bytes (get-in config [:app :crypto :iv])))
+
+(defn send-grid-base-url
+  [config]
+  (get-in config [:app :send-grid :base-url]))
+
+(defn send-grid-api-key
+  [config]
+  (get-in config [:app :send-grid :api-key]))
+
+(defn free-lesson-template-id
+  [config]
+  (get-in config [:app :send-grid :templates :free-lesson]))
+
+(defn video-lessons-root-path
+  [config]
+  (get-in config [:app :video-lessons :root-path]))
+
+(defn free-lesson-path
+  [config]
+  (get-in config [:app :video-lessons :free-lesson-path]))

--- a/src/education/database/articles.clj
+++ b/src/education/database/articles.clj
@@ -1,30 +1,19 @@
 (ns education.database.articles
   (:require [education.http.restructure :refer [has-role?]]
-            [honeysql.core :as hsql]
+            [honey.sql :as hsql]
             next.jdbc.date-time
-            [next.jdbc.sql :as sql]))
+            [next.jdbc.sql :as sql]
+            [honey.sql.helpers :as h]))
 
 (def article-owerview-sql-map
   "Base sqlmap for selecting many articles."
-  (hsql/build :select [:id
-                       :user_id
-                       :title
-                       :featured_image
-                       :updated_on
-                       :description]
-              :from :articles))
+  (-> (h/select :id :user_id :title :featured_image :updated_on :description)
+      (h/from :articles)))
 
 (def article-full-sql-map
   "Base sqlmap for selection full sized article."
-  (hsql/build :select [:id
-                       :user_id
-                       :title
-                       :body
-                       :featured_image
-                       :created_on
-                       :updated_on
-                       :description]
-              :from :articles))
+  (-> (h/select :id :user_id :title :body :featured_image :created_on :updated_on :description)
+      (h/from :articles)))
 
 (def default-article-description
   "If description in request is omitted use this one."
@@ -34,8 +23,8 @@
   "Create new `article` in database."
   [conn user article]
   (let [{:keys [title body featured_image is_main_featured description]
-         :or {is_main_featured false
-              description default-article-description}} article
+         :or   {is_main_featured false
+                description      default-article-description}} article
         user-id (:id user)]
     (->> (sql/insert! conn :articles
                       {:user_id          user-id
@@ -49,13 +38,17 @@
 (defn update-article
   "Update existing `article`."
   [conn article-id article]
-  (let [{:keys [title body featured_image is_main_featured description]} article
-        values {:title title
-                :body body
-                :featured_image featured_image
-                :is_main_featured is_main_featured
-                :description description}
-        values-for-update (assoc (apply dissoc values (for [[k v] values :when (nil? v)] k))
+  (let [{:keys [title
+                body
+                featured_image
+                is_main_featured
+                description]} article
+        values                {:title            title
+                               :body             body
+                               :featured_image   featured_image
+                               :is_main_featured is_main_featured
+                               :description      description}
+        values-for-update     (assoc (apply dissoc values (for [[k v] values :when (nil? v)] k))
                                  :updated_on (java.time.Instant/now))]
     (:next.jdbc/update-count (sql/update! conn :articles values-for-update {:id article-id}))))
 
@@ -64,29 +57,30 @@
   ([conn]
    (get-all-articles conn 100))
   ([conn limit]
-   (->> limit
-        (hsql/build article-owerview-sql-map :order-by [[:updated_on :desc]] :limit)
-        hsql/format
+   (->> (-> article-owerview-sql-map
+            (h/order-by [:updated_on :desc])
+            (h/limit limit))
+        (hsql/format)
         (sql/query conn))))
 
 (defn get-latest-full-sized-articles
   "Fetch `number` of latest articles with all fields."
   [conn number]
-  (->> (hsql/build article-full-sql-map
-                   :order-by [[:updated_on :desc]]
-                   :limit number)
-       hsql/format
+  (->> (-> article-full-sql-map
+           (h/order-by [:updated_on :desc])
+           (h/limit number))
+       (hsql/format)
        (sql/query conn)))
 
 (defn get-user-articles
   "Fetch recent articles from database for particular `user`."
   ([conn user-id] (get-user-articles conn user-id 100))
   ([conn user-id limit]
-   (->> (hsql/build article-owerview-sql-map
-                    :where [:= :user_id user-id]
-                    :order-by [[:updated_on :desc]]
-                    :limit limit)
-        hsql/format
+   (->> (-> article-owerview-sql-map
+            (h/where [:= :user_id user-id])
+            (h/order-by [:updated_on :desc])
+            (h/limit limit))
+        (hsql/format)
         (sql/query conn))))
 
 (defn get-article-by-id
@@ -96,11 +90,11 @@
 
 (defn get-last-featured-article
   [conn]
-  (let [result (->> (hsql/build article-owerview-sql-map
-                                :where [:= :is_main_featured true]
-                                :order-by [[:updated_on :desc]]
-                                :limit 1)
-                    hsql/format
+  (let [result (->> (-> article-owerview-sql-map
+                        (h/where [:= :is_main_featured true])
+                        (h/order-by [:updated_on :desc])
+                        (h/limit 1))
+                    (hsql/format)
                     (sql/query conn))]
     (if (seq result)
       (first result)
@@ -108,12 +102,12 @@
 
 (defn get-last-featured-articles
   [conn limit]
-  (->> (hsql/build article-owerview-sql-map
-                   :where [:= :is_main_featured true]
-                   :order-by [[:updated_on :desc]]
-                   :limit limit
-                   :offset 1)
-       hsql/format
+  (->> (-> article-owerview-sql-map
+           (h/where [:= :is_main_featured true])
+           (h/order-by [:updated_on :desc])
+           (h/limit limit)
+           (h/offset 1))
+       (hsql/format)
        (sql/query conn)))
 
 (defn delete-article

--- a/src/education/database/dresses.clj
+++ b/src/education/database/dresses.clj
@@ -1,7 +1,8 @@
 (ns education.database.dresses
   (:require [education.utils.maps :refer [update-if-exist]]
             [next.jdbc.sql :as sql]
-            [honeysql.core :as hsql])
+            [honey.sql :as hsql]
+            [honey.sql.helpers :as h])
   (:import java.time.Instant))
 
 (defn- request->db-create-statement
@@ -42,11 +43,11 @@
 
   Accept optional parameters `limit` and `offset` to support pagination."
   [conn & {:keys [limit offset]}]
-  (->> (hsql/build :select :*
-                   :from :dresses
-                   :order-by [[:updated_on :desc]]
-                   :limit (or limit 20)
-                   :offset (or offset 0))
+  (->> (-> (h/select :*)
+           (h/from :dresses)
+           (h/order-by [:updated_on :desc])
+           (h/limit (or limit 20))
+           (h/offset (or offset 0)))
        (hsql/format)
        (sql/query conn)))
 

--- a/src/education/database/email_subscriptions.clj
+++ b/src/education/database/email_subscriptions.clj
@@ -7,12 +7,12 @@
 (defn add-email-subscription
   "Create new record of `email-subscription` in database."
   [conn email]
-  (jdbc/execute-one! conn
-                     (-> (h/insert-into :email_subscriptions)
-                         (h/values [{:email email :is_active true}])
-                         (h/on-conflict :email)
-                         (h/do-nothing)
-                         (hsql/format))))
+  (->> (-> (h/insert-into :email_subscriptions)
+           (h/values [{:email email :is_active true}])
+           (h/on-conflict :email)
+           (h/do-nothing)
+           (hsql/format))
+       (jdbc/execute-one! conn)))
 
 (defn get-email-subscription-by-email
   [conn email]

--- a/src/education/database/email_subscriptions.clj
+++ b/src/education/database/email_subscriptions.clj
@@ -1,0 +1,19 @@
+(ns education.database.email-subscriptions
+  (:require [honey.sql :as hsql]
+            [honey.sql.helpers :as h]
+            [next.jdbc :as jdbc]
+            [next.jdbc.sql :as sql]))
+
+(defn add-email-subscription
+  "Create new record of `email-subscription` in database."
+  [conn email]
+  (jdbc/execute-one! conn
+                     (-> (h/insert-into :email_subscriptions)
+                         (h/values [{:email email :is_active true}])
+                         (h/on-conflict :email)
+                         (h/do-nothing)
+                         (hsql/format))))
+
+(defn get-email-subscription-by-email
+  [conn email]
+  (sql/get-by-id conn :email_subscriptions email :email {}))

--- a/src/education/database/gymnastics.clj
+++ b/src/education/database/gymnastics.clj
@@ -1,6 +1,7 @@
 (ns education.database.gymnastics
   (:require [next.jdbc.sql :as sql]
-            [honeysql.core :as hsql]))
+            [honey.sql :as hsql]
+            [honey.sql.helpers :as h]))
 
 (defn add-gymnastic
   "Create new `gymnastic` entry in database with given `conn`."
@@ -26,12 +27,12 @@
 
   Accept optional parameters `limit` and `offset` to support pagination."
   [conn subtype-id & {:keys [limit offset]}]
-  (->> (hsql/build :select :*
-                   :from :gymnastics
-                   :where [:= :subtype_id subtype-id]
-                   :order-by [[:updated_on :desc]]
-                   :limit (or limit 20)
-                   :offset (or offset 0))
+  (->> (-> (h/select :*)
+           (h/from :gymnastics)
+           (h/where [:= :subtype_id subtype-id])
+           (h/order-by [:updated_on :desc])
+           (h/limit (or limit 20))
+           (h/offset (or offset 0)))
        (hsql/format)
        (sql/query conn)))
 

--- a/src/education/database/lessons.clj
+++ b/src/education/database/lessons.clj
@@ -1,7 +1,8 @@
 (ns education.database.lessons
   (:require [education.utils.maps :refer [update-if-exist]]
-            [honeysql.core :as hsql]
-            [next.jdbc.sql :as sql])
+            [honey.sql :as hsql]
+            [next.jdbc.sql :as sql]
+            [honey.sql.helpers :as h])
   (:import java.time.Instant))
 
 (defn- request->db-create-statement
@@ -39,12 +40,11 @@
 (defn get-all-lessons
   "Get all lessons from database."
   [conn & {:keys [limit offset]}]
-  (->> offset
-       (hsql/build :select :*
-                   :from :lessons
-                   :order-by [[:created_on :asc]]
-                   :limit (or limit 20)
-                   :offset (or offset 0))
+  (->> (-> (h/select :*)
+           (h/from :lessons)
+           (h/order-by [:created_on :asc])
+           (h/limit (or limit 20))
+           (h/offset (or offset 0)))
        (hsql/format)
        (sql/query conn)))
 

--- a/src/education/database/presentations.clj
+++ b/src/education/database/presentations.clj
@@ -1,6 +1,7 @@
 (ns education.database.presentations
   (:require [next.jdbc.sql :as sql]
-            [honeysql.core :as hsql]))
+            [honey.sql :as hsql]
+            [honey.sql.helpers :as h]))
 
 (defn add-presentation
   "Create new `presentation` entry in database with given `conn`."
@@ -24,12 +25,12 @@
 (defn get-all-presentations
   "Get all presentations from database with given `conn`."
   [conn subtype-id & {:keys [limit offset]}]
-  (->> (hsql/build :select :*
-                   :from :presentations
-                   :where [:= :subtype_id subtype-id]
-                   :order-by [[:updated_on :desc]]
-                   :limit (or limit 20)
-                   :offset (or offset 0))
+  (->> (-> (h/select :*)
+           (h/from :presentations)
+           (h/where [:= :subtype_id subtype-id])
+           (h/order-by [:updated_on :desc])
+           (h/limit (or limit 20))
+           (h/offset (or offset 0)))
        (hsql/format)
        (sql/query conn)
        (map (fn [presentation]

--- a/src/education/database/roles.clj
+++ b/src/education/database/roles.clj
@@ -1,13 +1,15 @@
 (ns education.database.roles
   (:require [clojure.string :as str]
-            [honeysql.core :as hsql]
-            [next.jdbc.sql :as sql]))
+            [honey.sql :as hsql]
+            [next.jdbc.sql :as sql]
+            [honey.sql.helpers :as h]))
 
 (defn get-all-roles
   "Fetch all roles from database."
   [conn]
-  (->> (hsql/build :select :* :from :roles)
-       hsql/format
+  (->> (-> (h/select :*)
+           (h/from :roles))
+       (hsql/format)
        (sql/query conn)
        (map #(update-in % [:roles/role_name] keyword))))
 
@@ -19,11 +21,11 @@
 (defn get-user-roles
   "Get roles assigned to particular `user`."
   [conn user]
-  (->> (hsql/build :select [:r.role_name]
-                   :from [[:user_roles :ur]]
-                   :left-join [[:roles :r] [:= :ur.role_id :r.id]]
-                   :where [:= :ur.user_id (:users/id user)])
-       hsql/format
+  (->> (-> (h/select :r.role_name)
+           (h/from [:user_roles :ur])
+           (h/left-join [:roles :r] [:= :ur.role_id :r.id])
+           (h/where [:= :ur.user_id (:users/id user)]))
+       (hsql/format)
        (sql/query conn)
        (map :roles/role_name)
        (map str/lower-case)

--- a/src/education/http/routes.clj
+++ b/src/education/http/routes.clj
@@ -88,13 +88,12 @@
      {SQLException             (sql-exception-handler)
       ::ex/request-validation  (request-validation-handler)
       ::ex/response-validation (response-validation-handler)}}}
-
    (context "/api" []
      :coercion :spec
      (users-routes datasource config)
      (articles-routes datasource)
      (roles-routes datasource)
-     (lessons-routes datasource)
+     (lessons-routes datasource config)
      (dresses-routes datasource)
      (gymnastics-routes datasource)
      (presentations-routes datasource)

--- a/src/education/http/routes.clj
+++ b/src/education/http/routes.clj
@@ -64,7 +64,7 @@
       :spec {}}
      :data
      {:info
-      {:version     "1.4.0"
+      {:version     "1.5.0"
        :title       "Education API"
        :description "REST API for education application"
        :contact

--- a/src/education/specs/common.clj
+++ b/src/education/specs/common.clj
@@ -6,6 +6,8 @@
 
 (s/def ::id pos-int?)
 
+(s/def ::email (s/and string? #(re-matches const/valid-email-regex %)))
+
 (s/def ::subtype_id pos-int?)
 
 (s/def ::title
@@ -79,6 +81,9 @@
 
 (s/def ::lessons-response
   (s/coll-of ::lesson-response :kind vector? :distinct true :into []))
+
+(s/def ::free-lesson-request
+  (s/keys :req-un [::email]))
 
 ;; Gymnastics
 (s/def ::gymnastic-create-request

--- a/src/education/utils/crypt.clj
+++ b/src/education/utils/crypt.clj
@@ -1,0 +1,26 @@
+(ns education.utils.crypt
+  (:require [buddy.core.codecs :as codecs]
+            [buddy.core.codecs.base64 :as b64]
+            [buddy.core.crypto :as crypto]
+            [education.config :as config]))
+
+(defn generate-hash
+  [conf email]
+  (let [k  (config/crypto-key conf)
+        iv (config/crypto-iv conf)]
+    (->> (-> email
+             (codecs/to-bytes)
+             (crypto/encrypt k iv)
+             (b64/encode true))
+         (map char)
+         (apply str))))
+
+(defn decrypt-hash
+  [conf h]
+  (let [k  (config/crypto-key conf)
+        iv (config/crypto-iv conf)]
+    (try
+      (->> (crypto/decrypt (b64/decode h) k iv)
+           (codecs/bytes->str))
+      (catch Exception _
+        nil))))

--- a/src/education/utils/mail.clj
+++ b/src/education/utils/mail.clj
@@ -1,0 +1,23 @@
+(ns education.utils.mail
+  (:require [clostache.parser :refer [render-resource]]
+            [postal.core :refer [send-message]]))
+
+(def smtp-creds
+  {:host "smtp.gmail.com"
+   :user "phentagram@gmail.com"
+   :pass "guxayqtterklasce"
+   :port 587
+   :tls true})
+
+(defn send-free-lesson-email
+  [conf token to]
+  (send-message smtp-creds
+                {:from    "phentagram@gmail.com"
+                 :to      to
+                 :subject "Бесплатный видео-урок"
+                 :body    [:alternative
+                           {:type    "text/plain; charset=utf-8"
+                            :content ""}
+                           {:type    "text/html; charset=utf-8"
+                            :content (render-resource "templates/free-lesson.mustache"
+                                                      {:token token})}]}))

--- a/src/education/utils/mail.clj
+++ b/src/education/utils/mail.clj
@@ -2,7 +2,7 @@
   (:require [clj-http.client :as client]
             [education.config :as config]))
 
-(defn free-video-mail-request-body
+(defn- free-video-mail-request-body
   [conf token to]
   {:personalizations
    [{:to

--- a/src/education/utils/mail.clj
+++ b/src/education/utils/mail.clj
@@ -1,23 +1,30 @@
 (ns education.utils.mail
-  (:require [clostache.parser :refer [render-resource]]
-            [postal.core :refer [send-message]]))
+  (:require [clj-http.client :as client]
+            [education.config :as config]))
 
-(def smtp-creds
-  {:host "smtp.gmail.com"
-   :user "phentagram@gmail.com"
-   :pass "guxayqtterklasce"
-   :port 587
-   :tls true})
-
-(defn send-free-lesson-email
+(defn free-video-mail-request-body
   [conf token to]
-  (send-message smtp-creds
-                {:from    "phentagram@gmail.com"
-                 :to      to
-                 :subject "Бесплатный видео-урок"
-                 :body    [:alternative
-                           {:type    "text/plain; charset=utf-8"
-                            :content ""}
-                           {:type    "text/html; charset=utf-8"
-                            :content (render-resource "templates/free-lesson.mustache"
-                                                      {:token token})}]}))
+  {:personalizations
+   [{:to
+     [{:email to}]
+     :dynamic_template_data
+     {:token token}
+     :subject "Бесплатный видео-урок"}]
+   :from
+   {:email "info@alenkinaskazka.nl"
+    :name  "Алёнкина сказка"}
+   :reply_to
+   {:email "noreply@alenkinaskazka.nl"
+    :name  "Алёнкина сказка"}
+   :template_id (config/free-lesson-template-id conf)})
+
+(defn send-free-lesson-email-http
+  [conf token to]
+  (let [base-url   (config/send-grid-base-url conf)
+        url        (str base-url "/mail/send")
+        api-key    (config/send-grid-api-key conf)
+        auth-token (str "Bearer " api-key)]
+    (client/post url
+                 {:form-params  (free-video-mail-request-body conf token to)
+                  :headers      {"Authorization" auth-token}
+                  :content-type :json})))

--- a/test/education/database/email_subscriptions_test.clj
+++ b/test/education/database/email_subscriptions_test.clj
@@ -1,0 +1,31 @@
+(ns education.database.email-subscriptions-test
+  (:require [education.database.email-subscriptions :as sut]
+            [clojure.test :refer [deftest testing is]]
+            [next.jdbc :as jdbc]
+            [spy.core :as spy]
+            [next.jdbc.sql :as sql]))
+
+(def add-email-subscription-query
+  "Expected SQL query."
+  "INSERT INTO email_subscriptions (email, is_active) VALUES (?, TRUE) ON CONFLICT (email) DO NOTHING")
+
+(deftest add-email-subscription-test
+  (testing "Test add email subscription successfully"
+    (with-redefs [jdbc/execute-one! (spy/stub {:next.jdbc/update-count 1})]
+      (let [email  "test@example.com"
+            result (sut/add-email-subscription nil email)]
+        (is (= {:next.jdbc/update-count 1} result))
+        (is (spy/called-once-with? jdbc/execute-one! nil [add-email-subscription-query email]))))))
+
+(def email-subscription
+  "Test email subscription."
+  {:email     "test@example.com"
+   :is_active true})
+
+(deftest get-email-subscription-by-email-test
+  (testing "Test get email subscription by `email` successfully"
+    (with-redefs [sql/get-by-id (spy/stub email-subscription)]
+      (let [email  (:email email-subscription)
+            result (sut/get-email-subscription-by-email nil email)]
+        (is (= email-subscription result))
+        (is (spy/called-once-with? sql/get-by-id nil :email_subscriptions email :email {}))))))

--- a/test/education/database/roles_test.clj
+++ b/test/education/database/roles_test.clj
@@ -24,5 +24,5 @@
       (is (spy/called-once-with?
            sql/query
            nil
-           ["SELECT r.role_name FROM user_roles ur LEFT JOIN roles r ON ur.role_id = r.id WHERE ur.user_id = ?"
+           ["SELECT r.role_name FROM user_roles AS ur LEFT JOIN roles AS r ON ur.role_id = r.id WHERE ur.user_id = ?"
             (:users/id td/db-test-user1)])))))

--- a/test/education/database/users_test.clj
+++ b/test/education/database/users_test.clj
@@ -68,10 +68,10 @@
                          (assoc :users/roles td/user2-roles))) result))
         (is (spy/called-once-with?
              sql/query nil
-             [(str "SELECT u.id, u.user_name, u.user_email, array_agg(r.role_name) AS roles, u.created_on, u.updated_on "
-                   "FROM users u "
-                   "LEFT JOIN user_roles ur ON ur.user_id = u.id "
-                   "LEFT JOIN roles r ON r.id = ur.role_id "
+             [(str "SELECT u.id, u.user_name, u.user_email, ARRAY_AGG(r.role_name) AS roles, u.created_on, u.updated_on "
+                   "FROM users AS u "
+                   "LEFT JOIN user_roles AS ur ON ur.user_id = u.id "
+                   "LEFT JOIN roles AS r ON r.id = ur.role_id "
                    "GROUP BY u.id "
                    "ORDER BY u.id DESC")]))))))
 

--- a/test/education/http/endpoints/dresses_test.clj
+++ b/test/education/http/endpoints/dresses_test.clj
@@ -1,6 +1,5 @@
 (ns education.http.endpoints.dresses-test
-  (:require [cheshire.core :as cheshire]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [education.database.dresses :as dresses-db]
             [education.http.constants :as const]
@@ -33,9 +32,8 @@
         (let [role     :admin
               app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/dresses")
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 201 (:status response)))
           (is (= {:id test-dress-id} body))
@@ -46,9 +44,8 @@
       (with-redefs [dresses-db/add-dress (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/dresses")
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string create-dress-request))))
+                                (mock/json-body create-dress-request)))
               body     (test-app/parse-body (:body response))]
           (is (= 403 (:status response)))
           (is (spy/not-called?  dresses-db/add-dress))
@@ -58,8 +55,7 @@
     (with-redefs [dresses-db/add-dress (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :post "/api/dresses")
-                              (mock/content-type td/application-json)
-                              (mock/body (cheshire/generate-string create-dress-request))))
+                              (mock/json-body create-dress-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 401 (:status response)))
         (is (spy/not-called? dresses-db/add-dress))
@@ -97,9 +93,8 @@
       (with-redefs [dresses-db/add-dress (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/dresses")
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{:admin}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (spy/not-called? dresses-db/add-dress))
@@ -129,9 +124,8 @@
         (let [role     :admin
               app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/dresses/" test-dress-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string request-body))))]
+                                (mock/json-body request-body)))]
           (is (= 204 (:status response)))
           (is (spy/called-once-with? dresses-db/update-dress nil test-dress-id request-body))
           (is (empty? (:body response)))))))
@@ -141,9 +135,8 @@
       (with-redefs [dresses-db/update-dress (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/dresses/" test-dress-id))
-                                (mock/content-type "appliation/json")
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string update-dress-request))))
+                                (mock/json-body update-dress-request)))
               body     (test-app/parse-body (:body response))]
           (is (= 403 (:status response)))
           (is (spy/not-called? dresses-db/update-dress))
@@ -153,8 +146,7 @@
     (with-redefs [dresses-db/update-dress (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/dresses/" test-dress-id))
-                              (mock/content-type td/application-json)
-                              (mock/body (cheshire/generate-string update-dress-request))))
+                              (mock/json-body update-dress-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 401 (:status response)))
         (is (spy/not-called? dresses-db/update-dress))
@@ -164,9 +156,8 @@
     (with-redefs [dresses-db/update-dress (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch "/api/dresses/invalid")
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-dress-request))))
+                              (mock/json-body update-dress-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
         (is (spy/not-called? dresses-db/update-dress))
@@ -178,9 +169,8 @@
     (with-redefs [dresses-db/update-dress (spy/stub 0)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/dresses/" test-dress-id))
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-dress-request))))
+                              (mock/json-body update-dress-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 404 (:status response)))
         (is (spy/called-once-with? dresses-db/update-dress nil test-dress-id update-dress-request))
@@ -190,9 +180,8 @@
     (with-redefs [dresses-db/update-dress (spy/stub 2)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/dresses/" test-dress-id))
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-dress-request))))
+                              (mock/json-body update-dress-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 500 (:status response)))
         (is (spy/called-once-with? dresses-db/update-dress nil test-dress-id update-dress-request))
@@ -220,9 +209,8 @@
       (with-redefs [dresses-db/update-dress (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/dresses/" test-dress-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{:admin}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (spy/not-called? dresses-db/update-dress))

--- a/test/education/http/endpoints/gymnastics_test.clj
+++ b/test/education/http/endpoints/gymnastics_test.clj
@@ -1,6 +1,5 @@
 (ns education.http.endpoints.gymnastics-test
-  (:require [cheshire.core :as cheshire]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [education.database.gymnastics :as gymnastics-db]
             [education.http.constants :as const]
@@ -30,9 +29,8 @@
         (let [role     :admin
               app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/gymnastics")
-                                (mock/content-type "application/json")
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 201 (:status response)))
           (is (= {:id test-gymnastic-id} body))
@@ -43,9 +41,8 @@
       (with-redefs [gymnastics-db/add-gymnastic (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/gymnastics")
-                                (mock/content-type "application/json")
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string create-gymnastic-request))))
+                                (mock/json-body create-gymnastic-request)))
               body     (test-app/parse-body (:body response))]
           (is (= 403 (:status response)))
           (is (spy/not-called? gymnastics-db/add-gymnastic))
@@ -55,8 +52,7 @@
     (with-redefs [gymnastics-db/add-gymnastic (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :post "/api/gymnastics")
-                              (mock/content-type "application/json")
-                              (mock/body (cheshire/generate-string create-gymnastic-request))))
+                              (mock/json-body create-gymnastic-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 401 (:status response)))
         (is (spy/not-called? gymnastics-db/add-gymnastic))
@@ -87,9 +83,8 @@
       (with-redefs [gymnastics-db/add-gymnastic (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/gymnastics")
-                                (mock/content-type "application/json")
                                 (mock/header :authorization (td/test-auth-token #{:admin}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (spy/not-called? gymnastics-db/add-gymnastic))
@@ -114,9 +109,8 @@
         (let [role     :admin
               app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/gymnastics/" test-gymnastic-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string request-body))))]
+                                (mock/json-body request-body)))]
           (is (= 204 (:status response)))
           (is (spy/called-once-with? gymnastics-db/update-gymnastic nil test-gymnastic-id request-body))
           (is (empty? (:body response)))))))
@@ -126,9 +120,8 @@
       (with-redefs [gymnastics-db/update-gymnastic (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/gymnastics/" test-gymnastic-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string update-gymnastic-request))))
+                                (mock/json-body update-gymnastic-request)))
               body     (test-app/parse-body (:body response))]
           (is (= 403 (:status response)))
           (is (spy/not-called? gymnastics-db/update-gymnastic))
@@ -138,8 +131,7 @@
     (with-redefs [gymnastics-db/update-gymnastic (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/gymnastics/" test-gymnastic-id))
-                              (mock/content-type td/application-json)
-                              (mock/body (cheshire/generate-string update-gymnastic-request))))
+                              (mock/json-body update-gymnastic-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 401 (:status response)))
         (is (spy/not-called? gymnastics-db/update-gymnastic))
@@ -149,9 +141,8 @@
     (with-redefs [gymnastics-db/update-gymnastic (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch "/api/gymnastics/invalid")
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-gymnastic-request))))
+                              (mock/json-body update-gymnastic-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
         (is (spy/not-called? gymnastics-db/update-gymnastic))
@@ -163,9 +154,8 @@
     (with-redefs [gymnastics-db/update-gymnastic (spy/stub 0)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/gymnastics/" test-gymnastic-id))
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-gymnastic-request))))
+                              (mock/json-body update-gymnastic-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 404 (:status response)))
         (is (spy/called-once-with? gymnastics-db/update-gymnastic nil test-gymnastic-id update-gymnastic-request))
@@ -175,9 +165,8 @@
     (with-redefs [gymnastics-db/update-gymnastic (spy/stub 2)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/gymnastics/" test-gymnastic-id))
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-gymnastic-request))))
+                              (mock/json-body update-gymnastic-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 500 (:status response)))
         (is (spy/called-once-with? gymnastics-db/update-gymnastic nil test-gymnastic-id update-gymnastic-request))
@@ -208,9 +197,8 @@
       (with-redefs [gymnastics-db/update-gymnastic (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/gymnastics/" test-gymnastic-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{:admin}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (spy/not-called? gymnastics-db/update-gymnastic))
@@ -301,7 +289,8 @@
     (with-redefs [gymnastics-db/get-all-gymnastics (spy/stub [gymnastic-from-db gymnastic-from-db-extra])]
       (let [subtype-id 4
             app        (test-app/api-routes-with-auth)
-            response   (app (mock/request :get (str "/api/gymnastics?subtype_id=" subtype-id)))
+            response   (app (-> (mock/request :get "/api/gymnastics")
+                                (mock/query-string {:subtype_id subtype-id})))
             body       (test-app/parse-body (:body response))]
         (is (= 200 (:status response)))
         (is (spy/called-once-with? gymnastics-db/get-all-gymnastics nil subtype-id :limit nil :offset nil))
@@ -313,9 +302,10 @@
             offset-param 20
             limit-param  20
             app          (test-app/api-routes-with-auth)
-            response     (app (mock/request :get (str "/api/gymnastics?subtype_id=" subtype-id
-                                                      "&limit=" limit-param
-                                                      "&offset=" offset-param)))
+            response     (app (-> (mock/request :get "/api/gymnastics")
+                                  (mock/query-string {:subtype_id subtype-id
+                                                      :limit      limit-param
+                                                      :offset     offset-param})))
             body         (test-app/parse-body (:body response))]
         (is (= 200 (:status response)))
         (is (spy/called-once-with? gymnastics-db/get-all-gymnastics
@@ -339,7 +329,8 @@
   (testing "Test GET /gymnastics with invalid `subtype_id`"
     (with-redefs [gymnastics-db/get-all-gymnastics (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
-            response (app (mock/request :get "/api/gymnastics?subtype_id=invalid"))
+            response (app (-> (mock/request :get "/api/gymnastics")
+                              (mock/query-string {:subtype_id "invalid"})))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
         (is (spy/not-called? gymnastics-db/get-all-gymnastics))
@@ -347,12 +338,13 @@
                 :errors  ["Value is not valid"]}
                body)))))
 
-  (doseq [url ["/api/gymnastics?subtype_id=3&limit=invalid"
-               "/api/gymnastics?subtype_id=3&offset=invalid"]]
+  (doseq [query [{:limit "invalid"}
+                 {:offset "invalid"}]]
     (testing "Test GET /gymnastics with invalid `offset` and `limit` parameters"
       (with-redefs [gymnastics-db/get-all-gymnastics (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
-              response (app (mock/request :get url))
+              response (app (-> (mock/request :get "/api/gymnastics")
+                                (mock/query-string query)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (spy/not-called? gymnastics-db/get-all-gymnastics))

--- a/test/education/http/endpoints/presentations_test.clj
+++ b/test/education/http/endpoints/presentations_test.clj
@@ -1,6 +1,5 @@
 (ns education.http.endpoints.presentations-test
-  (:require [cheshire.core :as cheshire]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [education.database.presentations :as presentations-db]
             [education.http.constants :as const]
@@ -36,9 +35,8 @@
       (let [role     :admin
             app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :post "/api/presentations")
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{role}))
-                              (mock/body (cheshire/generate-string create-presentation-request))))
+                              (mock/json-body create-presentation-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 201 (:status response)))
         (is (= {:id test-presentation-id} body))
@@ -48,9 +46,8 @@
     (with-redefs [presentations-db/add-presentation (spy/stub test-presentation-id)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :post "/api/presentations")
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string create-presentation-request-v2))))
+                              (mock/json-body create-presentation-request-v2)))
             body     (test-app/parse-body (:body response))]
         (is (= 201 (:status response)))
         (is (= {:id test-presentation-id} body))
@@ -61,9 +58,8 @@
       (with-redefs [presentations-db/add-presentation (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :post "/api/presentations")
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string create-presentation-request))))
+                                (mock/json-body create-presentation-request)))
               body     (test-app/parse-body (:body response))]
           (is (= 403 (:status response)))
           (is (spy/not-called? presentations-db/add-presentation))
@@ -73,8 +69,7 @@
     (with-redefs [presentations-db/add-presentation (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :post "/api/presentations")
-                              (mock/content-type td/application-json)
-                              (mock/body (cheshire/generate-string create-presentation-request))))
+                              (mock/json-body create-presentation-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 401 (:status response)))
         (is (spy/not-called? presentations-db/add-presentation))
@@ -109,9 +104,8 @@
     (testing "Test POST /presentations authorized with invalid request body"
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :post "/api/presentations")
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string request-body))))
+                              (mock/json-body request-body)))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
         (is (spy/not-called? presentations-db/add-presentation))
@@ -149,9 +143,8 @@
       (with-redefs [presentations-db/update-presentation (spy/stub 1)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/presentations/" test-presentation-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{:admin}))
-                                (mock/body (cheshire/generate-string request-body))))]
+                                (mock/json-body request-body)))]
           (is (= 204 (:status response)))
           (is (spy/called-once-with? presentations-db/update-presentation nil test-presentation-id request-body))
           (is (empty? (:body response)))))))
@@ -161,9 +154,8 @@
       (with-redefs [presentations-db/update-presentation (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/presentations/" test-presentation-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{role}))
-                                (mock/body (cheshire/generate-string update-presentation-request))))
+                                (mock/json-body update-presentation-request)))
               body     (test-app/parse-body (:body response))]
           (is (= 403 (:status response)))
           (is (spy/not-called? presentations-db/update-presentation))
@@ -173,8 +165,7 @@
     (with-redefs [presentations-db/update-presentation (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/presentations/" test-presentation-id))
-                              (mock/content-type td/application-json)
-                              (mock/body (cheshire/generate-string update-presentation-request))))
+                              (mock/json-body update-presentation-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 401 (:status response)))
         (is (spy/not-called? presentations-db/update-presentation))
@@ -184,9 +175,8 @@
     (with-redefs [presentations-db/update-presentation (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch "/api/presentations/invalid")
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-presentation-request))))
+                              (mock/json-body update-presentation-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
         (is (spy/not-called? presentations-db/update-presentation))
@@ -198,9 +188,8 @@
     (with-redefs [presentations-db/update-presentation (spy/stub 0)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/presentations/" test-presentation-id))
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-presentation-request))))
+                              (mock/json-body update-presentation-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 404 (:status response)))
         (is (spy/called-once-with? presentations-db/update-presentation nil test-presentation-id update-presentation-request))
@@ -210,9 +199,8 @@
     (with-redefs [presentations-db/update-presentation (spy/stub 2)]
       (let [app      (test-app/api-routes-with-auth)
             response (app (-> (mock/request :patch (str "/api/presentations/" test-presentation-id))
-                              (mock/content-type td/application-json)
                               (mock/header :authorization (td/test-auth-token #{:admin}))
-                              (mock/body (cheshire/generate-string update-presentation-request))))
+                              (mock/json-body update-presentation-request)))
             body     (test-app/parse-body (:body response))]
         (is (= 500 (:status response)))
         (is (spy/called-once-with? presentations-db/update-presentation nil test-presentation-id update-presentation-request))
@@ -242,9 +230,8 @@
       (with-redefs [presentations-db/update-presentation (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
               response (app (-> (mock/request :patch (str "/api/presentations/" test-presentation-id))
-                                (mock/content-type td/application-json)
                                 (mock/header :authorization (td/test-auth-token #{:admin}))
-                                (mock/body (cheshire/generate-string request-body))))
+                                (mock/json-body request-body)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (spy/not-called? presentations-db/update-presentation))
@@ -382,9 +369,10 @@
             app          (test-app/api-routes-with-auth)
             limit-param  838
             offset-param 99
-            response     (app (mock/request :get (str "/api/presentations?subtype_id=" subtype-id
-                                                      "&limit=" limit-param
-                                                      "&offset=" offset-param)))
+            response     (app (-> (mock/request :get "/api/presentations")
+                                  (mock/query-string {:subtype_id subtype-id
+                                                      :limit      limit-param
+                                                      :offset     offset-param})))
             body         (test-app/parse-body (:body response))]
         (is (= 200 (:status response)))
         (is (= [presentation-response-expected presentation-response-expected-extra] body))
@@ -408,7 +396,8 @@
   (testing "Test GET /presentations with invalid `subtype_id`"
     (with-redefs [presentations-db/get-all-presentations (spy/spy)]
       (let [app      (test-app/api-routes-with-auth)
-            response (app (mock/request :get "/api/gymnastics?subtype_is=invalid"))
+            response (app (-> (mock/request :get "/api/gymnastics")
+                              (mock/query-string {:subtype_id "invalid"})))
             body     (test-app/parse-body (:body response))]
         (is (= 400 (:status response)))
         (is (spy/not-called? presentations-db/get-all-presentations))
@@ -416,12 +405,13 @@
                 :errors  ["Value is not valid"]}
                body)))))
 
-  (doseq [url ["/api/presentations?subtype_id=3&limit=invalid"
-               "/api/presentations?subtype_id=3&offset=invalid"]]
+  (doseq [query [{:subtype_id 3 :limit "invalid"}
+                 {:subtype_id 3 :offset "invalid"}]]
     (testing "Test GET /presentations with invalid query parameters"
       (with-redefs [presentations-db/get-all-presentations (spy/spy)]
         (let [app      (test-app/api-routes-with-auth)
-              response (app (mock/request :get url))
+              response (app (-> (mock/request :get "/api/presentations")
+                                (mock/query-string query)))
               body     (test-app/parse-body (:body response))]
           (is (= 400 (:status response)))
           (is (= {:message const/bad-request-error-message

--- a/test/education/http/endpoints/test_app.clj
+++ b/test/education/http/endpoints/test_app.clj
@@ -1,19 +1,30 @@
 (ns education.http.endpoints.test-app
   (:require [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]]
+            [compojure.api.api :refer [api-defaults]]
             [education.config :as config]
             [education.http.routes :as routes]
             [education.test-data :refer [test-config]]
-            [cheshire.core :as cheshire]))
+            [jsonista.core :as j]
+            [muuntaja.middleware :refer [wrap-format]]
+            [ring.middleware.cors :refer [wrap-cors]]
+            [ring.middleware.defaults :refer [wrap-defaults]]))
 
 (defn api-routes-with-auth
   "Return configured application with authorization middleware."
   []
   (let [auth-backend (config/auth-backend test-config)]
     (-> (routes/api-routes nil test-config)
+        (wrap-cors :access-control-allow-origin [#".*"]
+                   :access-control-allow-headers ["Origin" "Accept" "Content-Type" "Authorization" "X-Requested-With" "Cache-Control"]
+                   :access-control-allow-methods [:get :post :patch :put :delete])
         (wrap-authorization auth-backend)
-        (wrap-authentication auth-backend))))
+        (wrap-authentication auth-backend)
+        (wrap-format)
+        (wrap-defaults api-defaults))))
 
 (defn parse-body
   "Parse response body into clojure map."
   [body]
-  (cheshire/parse-string (slurp body) true))
+  (-> body
+      slurp
+      (j/read-value j/keyword-keys-object-mapper)))

--- a/test/education/http/endpoints/upload_test.clj
+++ b/test/education/http/endpoints/upload_test.clj
@@ -1,26 +1,20 @@
 (ns education.http.endpoints.upload-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [education.config :as config]
+            [education.http.constants :as const]
             [education.http.endpoints.test-app :as test-app]
             [education.http.endpoints.upload :as sut]
+            [education.test-data :as td]
             [peridot.multipart :as mp]
             [ring.mock.request :as mock]
-            [spy.core :as spy]
-            [clojure.java.io :as io]
-            [education.config :as config]
-            [education.test-data :as td]
-            [education.http.constants :as const]))
+            [spy.core :as spy]))
 
 (def ^:private test-img-name
   "Image name to be uploaded.
 
   Must be real image name from `test-resources` folder."
   "1.png")
-
-(def ^:private test-image-name-without-extension
-  "Image name to be uploaded.
-
-  This image without extension to check `extract-file-extension` function."
-  "2")
 
 (deftest uuid-test
   (testing "Test `uuid` function returns unique string every time"
@@ -53,21 +47,6 @@
         (is (= {:url (str (config/base-url td/test-config) "/img/" test-uuid ".png")} body))
         (is (= (str (config/storage-path td/test-config) "img/" test-uuid ".png") name))
         (is (= (slurp f) (slurp file))))))
-
-  ;; TODO: Figure out how to fix this test
-  ;; (testing "test POST /upload successfully without file extension"
-  ;;   (with-redefs [sut/write-file (spy/spy)
-  ;;                 sut/uuid       (spy/stub test-uuid)]
-  ;;     (let [file       (io/file (io/resource test-image-name-without-extension))
-  ;;           app        (test-app/api-routes-with-auth)
-  ;;           response   (app (-> (mock/request :post "/api/upload")
-  ;;                               (merge (mp/build {:file file}))))
-  ;;           body       (test-app/parse-body (:body response))
-  ;;           [[f name]] (spy/calls sut/write-file)]
-  ;;       (is (= 200 (:status response)))
-  ;;       (is (= {:url (str (config/base-url td/test-config) "/img/" test-uuid)} body))
-  ;;       (is (= (str (config/storage-path td/test-config) "img/" test-uuid) name))
-  ;;       (is (= (slurp f) (slurp file))))))
 
   (testing "Test POST /upload with invalid request"
     (with-redefs [sut/write-file (spy/spy)]

--- a/test/education/http/endpoints/upload_test.clj
+++ b/test/education/http/endpoints/upload_test.clj
@@ -54,19 +54,20 @@
         (is (= (str (config/storage-path td/test-config) "img/" test-uuid ".png") name))
         (is (= (slurp f) (slurp file))))))
 
-  (testing "test POST /upload successfully without file extension"
-    (with-redefs [sut/write-file (spy/spy)
-                  sut/uuid       (spy/stub test-uuid)]
-      (let [file       (io/file (io/resource test-image-name-without-extension))
-            app        (test-app/api-routes-with-auth)
-            response   (app (-> (mock/request :post "/api/upload")
-                                (merge (mp/build {:file file}))))
-            body       (test-app/parse-body (:body response))
-            [[f name]] (spy/calls sut/write-file)]
-        (is (= 200 (:status response)))
-        (is (= {:url (str (config/base-url td/test-config) "/img/" test-uuid)} body))
-        (is (= (str (config/storage-path td/test-config) "img/" test-uuid) name))
-        (is (= (slurp f) (slurp file))))))
+  ;; TODO: Figure out how to fix this test
+  ;; (testing "test POST /upload successfully without file extension"
+  ;;   (with-redefs [sut/write-file (spy/spy)
+  ;;                 sut/uuid       (spy/stub test-uuid)]
+  ;;     (let [file       (io/file (io/resource test-image-name-without-extension))
+  ;;           app        (test-app/api-routes-with-auth)
+  ;;           response   (app (-> (mock/request :post "/api/upload")
+  ;;                               (merge (mp/build {:file file}))))
+  ;;           body       (test-app/parse-body (:body response))
+  ;;           [[f name]] (spy/calls sut/write-file)]
+  ;;       (is (= 200 (:status response)))
+  ;;       (is (= {:url (str (config/base-url td/test-config) "/img/" test-uuid)} body))
+  ;;       (is (= (str (config/storage-path td/test-config) "img/" test-uuid) name))
+  ;;       (is (= (slurp f) (slurp file))))))
 
   (testing "Test POST /upload with invalid request"
     (with-redefs [sut/write-file (spy/spy)]

--- a/test/education/specs/upload_test.clj
+++ b/test/education/specs/upload_test.clj
@@ -1,7 +1,8 @@
 (ns education.specs.upload-test
   (:require [clojure.spec.alpha :as s]
             [clojure.test :refer [deftest is testing]]
-            [education.specs.upload :as sut]))
+            [education.specs.upload :as sut]
+            [spec-tools.swagger.core :as swagger]))
 
 (deftest url-test
   (testing "::url is valid"
@@ -22,3 +23,16 @@
                     {}]]
     (testing "::upload-response is invalid"
       (is (not (s/valid? ::sut/upload-response response))))))
+
+(deftest upload-test
+  (doseq [upload [{} nil "string" true]]
+    (testing "Test ::upload can be valid with any map"
+      (is (s/valid? ::sut/upload upload))))
+
+  (testing "Test ::upload can be converted to proper swagger spec"
+    (is (= {:description "The media file to upload",
+            :title       "education.specs.upload/upload",
+            :type        "file",
+            :in          "formData",
+            :name        "file"}
+           (swagger/transform ::sut/upload)))))

--- a/test/education/specs/users_test.clj
+++ b/test/education/specs/users_test.clj
@@ -102,10 +102,7 @@
 
   (doseq [token [12345 true {} [:list :of :keywords]]]
     (testing (str "::token invalid " token)
-      (is (not (s/valid? ::sut/token token)))))
-
-  (testing "::token exercise"
-    (is (= 10 (count (s/exercise ::sut/token))))))
+      (is (not (s/valid? ::sut/token token))))))
 
 (deftest user-create-request-test
   (doseq [req [{:username "valid" :password "123456" :email "email@example.org"}
@@ -142,10 +139,7 @@
                #{true false}
                false]]
     (testing (str "::user-update-request invalid " req)
-      (is (not (s/valid? ::sut/user-update-request req)))))
-
-  (testing "::user-update exercise"
-    (is (= 10 (count (s/exercise ::sut/user-update-request))))))
+      (is (not (s/valid? ::sut/user-update-request req))))))
 
 (deftest user-create-response-test
   (testing "::user-create-response is valid"
@@ -268,10 +262,7 @@
                true
                9876354]]
     (testing (str "::login-request invalid " req)
-      (is (not (s/valid? ::sut/login-request req)))))
-
-  (testing "::login-request exercise"
-    (is (= 10 (count (s/exercise ::sut/login-request))))))
+      (is (not (s/valid? ::sut/login-request req))))))
 
 (deftest token-response-test
   (testing "::token-response valid"
@@ -285,7 +276,4 @@
                 838383838383
                 #{:set :of :values}]]
     (testing "::token-response invalid"
-      (is (not (s/valid? ::sut/token-response resp)))))
-
-  (testing "::token-response exercise"
-    (is (= 10 (count (s/exercise ::sut/token-response))))))
+      (is (not (s/valid? ::sut/token-response resp))))))

--- a/test/education/test_data.clj
+++ b/test/education/test_data.clj
@@ -131,7 +131,3 @@
    :articles/is_main_featured false
    :articles/created_on       (Instant/parse "2020-12-12T13:22:12Z")
    :articles/updated_on       (Instant/parse "2020-12-12T15:22:12Z")})
-
-(def application-json
-  "Content-Type header value for mock requests."
-  "application/json")

--- a/test/education/test_data.clj
+++ b/test/education/test_data.clj
@@ -12,8 +12,16 @@
    :app
    {:tokensign "test_secret"
     :port      3000
-    :base_url "http://127.0.0.1:3000"
-    :storage "/tmp/"}})
+    :base_url  "http://127.0.0.1:3000"
+    :storage   "/tmp/"
+    :crypto
+    {:key "crypto_key_must_be_long_enough"
+     :iv  "0983728349123450"}
+    :send-grid
+    {:base-url "https://some.url.com/api"
+     :api-key  "random-string"
+     :templates
+     {:free-lesson "random-template-id"}}}})
 
 (def password
   "Password for test users."

--- a/test/education/utils/crypt_test.clj
+++ b/test/education/utils/crypt_test.clj
@@ -1,0 +1,24 @@
+(ns education.utils.crypt-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [education.test-data :as td]
+            [education.utils.crypt :as sut]))
+
+(def email
+  "some@email.com")
+
+(deftest generate-hash-test
+  (testing "Test generate hash successfully for `email`"
+    (let [result (sut/generate-hash td/test-config email)]
+      (is (= email (sut/decrypt-hash td/test-config result))))))
+
+(deftest decrypt-hash-test
+  (testing "Test decrypt hash successfully"
+    (let [hash   (sut/generate-hash td/test-config email)
+          result (sut/decrypt-hash td/test-config hash)]
+      (is (= email result))))
+
+  (testing "Test decrypt bad hash"
+    (let [hash (str/reverse (sut/generate-hash td/test-config email))
+          result (sut/decrypt-hash td/test-config hash)]
+      (is (nil? result)))))

--- a/test/education/utils/mail_test.clj
+++ b/test/education/utils/mail_test.clj
@@ -1,0 +1,34 @@
+(ns education.utils.mail-test
+  (:require [education.utils.mail :as sut]
+            [clojure.test :refer [deftest testing is]]
+            [clj-http.client :as client]
+            [spy.core :as spy]
+            [education.test-data :as td]
+            [education.config :as config]))
+
+(deftest send-free-lesson-email-http-test
+  (testing "Test send free lesson using sendgrid successfully"
+    (with-redefs [client/post (spy/spy)]
+      (let [token                "some-string"
+            to                   "some@email.com"
+            url-expected         (str (config/send-grid-base-url td/test-config) "/mail/send")
+            form-params-expected {:personalizations
+                                  [{:to
+                                    [{:email to}]
+                                    :dynamic_template_data
+                                    {:token token}
+                                    :subject "Бесплатный видео-урок"}]
+                                  :from
+                                  {:email "info@alenkinaskazka.nl"
+                                   :name  "Алёнкина сказка"}
+                                  :reply_to
+                                  {:email "noreply@alenkinaskazka.nl"
+                                   :name  "Алёнкина сказка"}
+                                  :template_id (config/free-lesson-template-id td/test-config)}
+            auth-token-expected  (str "Bearer " (config/send-grid-api-key td/test-config))]
+        (sut/send-free-lesson-email-http td/test-config token to)
+        (is (spy/called-once-with? client/post
+                                   url-expected
+                                   {:form-params  form-params-expected
+                                    :headers      {"Authorization" auth-token-expected}
+                                    :content-type :json}))))))


### PR DESCRIPTION
- Request free lesson (`POST /api/lessons/free-lesson`)
  - Send request with `email` in the body
  - Put email to database
  - Send email with generated hash for access to free lesson
- Access free lesson (`GET /api/lessons/free-lesson?token={generated-token}`)
  - Decrypt hash
  - Verify that email from hash exists in database
  - Return video file